### PR TITLE
Introducing new features and changing XPath numbering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+**/_version.py
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -123,7 +124,7 @@ celerybeat.pid
 .env
 .venv
 env/
-venv/
+*venv*/
 ENV/
 env.bak/
 venv.bak/

--- a/pds4indextools/pds4_create_xml_index.py
+++ b/pds4indextools/pds4_create_xml_index.py
@@ -440,6 +440,7 @@ def main():
         if args.disambiguate_xpaths:
                 elements = ()
                 xpath_elements = []
+                tags = []
                 for key in list(xml_results.keys()):
                     xpath_elements.append(grab_elements(key))
                 
@@ -447,8 +448,10 @@ def main():
 
                 for key in list(xml_results.keys()):
                     elements = grab_elements(key)
-                    if elements not in duplicates:
-                        value = elements[-1]
+                    tag = elements[-1]
+                    if elements not in duplicates and elements[-1] not in tags:
+                        value = tag
+                        tags.append(tag)
                     else:
                         value = key
                     xml_results[value] = xml_results.pop(key)

--- a/pds4indextools/pds4_create_xml_index.py
+++ b/pds4indextools/pds4_create_xml_index.py
@@ -1,3 +1,47 @@
+"""
+XML Bundle Scraper
+This script scrapes XML files within specified directories, extracts information from
+user-defined XML elements, and generates a CSV index file. The script provides options
+for customizing the extraction process, such as specifying XPath headers, limiting
+search levels, and selecting elements to scrape.
+Usage:
+    python xml_bundle_scraper.py <directorypath> <pattern>
+        [--elements-file ELEMENTS_FILE]
+        [--disambiguate-xpaths]
+        [--output-file OUTPUT_FILE]
+        [--verbose]
+        [--sort-by SORT_BY] 
+        [--clean-header-field-names]
+        [--extra-file-info EXTRA_FILE_INFO]
+        [--config-file CONFIG_FILE]
+Arguments:
+    directorypath        The path to the directory containing the bundle to scrape.
+    pattern              The glob pattern(s) (which may include wildcards like *, ?,
+                         and **) for the files you wish to index. Multiple patterns
+                         may be specified separated by spaces. Surround each pattern
+                         with quotes.
+    --elements-file ELEMENTS_FILE
+                         Optional text file containing elements to scrape.
+    --disambiguate-xpaths
+                         Replace unique XPath headers with shortened versions.
+    --output-file OUTPUT_FILE
+                         The output path and filename for the resulting index file.
+    --verbose            Activate verbose printed statements during runtime.
+    --sort-by SORT_BY    Sort the index file by a chosen set of columns.
+    --clean-header-field-names
+                         Replace the ":" and "/" with Windows-friendly characters.
+    --extra-file-info EXTRA_FILE_INFO  
+                         Add additional column(s) to the index file containing file or
+                         bundle information. Possible values are: "LID", "filename",
+                         "filepath", "bundle", and "bundle_lid". Multiple values may be
+                         specified separated by spaces.
+    --config-file CONFIG_FILE
+                         An optional .ini configuration file for further customization.
+Example:
+python3 pds4_create_xml_index.py <toplevel_directory> "glob_path1" "glob_path2" 
+--output_file <outputfile> --elements-file sample_elements.txt --verbose
+"""
+
 import argparse
 import configparser
 from lxml import etree
@@ -55,6 +99,14 @@ def default_value_for_nil(config, data_type, nil_value):
 
 
 def grab_elements(xpath):
+    """Extract elements from an XPath in the order they appear.
+
+    Inputs:
+        xpath    The XPath of a scraped element
+
+    Returns:
+        The tuple of elements the XPath is composed of.
+    """
     elements = ()
     parts = xpath.split('/')
 
@@ -103,7 +155,7 @@ def load_config_file(specified_config_file):
 def process_schema_location(file_path):
     """Process schema location from an XML file.
 
-    Args:
+    Inputs:
         file_path    Path to the XML file.
 
     Returns:
@@ -383,7 +435,7 @@ def main():
 
         for key in list(xml_results.keys()):
             process_tags(xml_results, key, root,
-                         namespaces, prefixes, args)
+                         namespaces, prefixes)
 
         if args.disambiguate_xpaths:
                 elements = ()
@@ -427,4 +479,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-    

--- a/pds4indextools/pds4_create_xml_index.py
+++ b/pds4indextools/pds4_create_xml_index.py
@@ -266,30 +266,17 @@ def renumber_xpaths(xpaths):
 
     xpath_map = {}
 
-    # split_xpaths is a list containing tuples of
-    #   (full_xpath, parent, child, prefix_of_parent, num_of_parent)
-    # If there is no child, child is None
-    # If there is no number in [n], num_of_parent is None
     split_xpaths = [split_xpath_prefix_and_num(x) for x in xpaths]
 
     # Group split_xpaths by prefix
     for prefix, prefix_group in groupby(split_xpaths, lambda x: x.prefix):
         prefix_group_list = list(prefix_group)
 
-        # The parents in the resulting group may have unique IDs.
-        # We collect those IDs and create a mapping from the original numbers
-        # to a new set of suffixes of the form "[<n>]" where <n> is sequentially
-        # increasing starting at 1. We also add a special entry for the empty
-        # suffix when there is no number.
         unique_nums = sorted(list(set(x.num for x in prefix_group_list
                                             if x.num is not None)))
         renumber_map = {x: f'[{i+1}]' for i, x in enumerate(unique_nums)}
         renumber_map[None] = ''
 
-        # We further group these by unique parent (including the number)
-        # and recursively process all children for each unique parent.
-        # When the child map is returned, we update our map using the number
-        # remapping for the current parent combined with the child map.
         for parent, parent_group in groupby(prefix_group_list,
                                             lambda x: x.parent):
             parent_group_list = list(parent_group)

--- a/pds4indextools/pds4_create_xml_index.py
+++ b/pds4indextools/pds4_create_xml_index.py
@@ -4,6 +4,7 @@ This script scrapes XML files within specified directories, extracts information
 user-defined XML elements, and generates a CSV index file. The script provides options
 for customizing the extraction process, such as specifying XPath headers, limiting
 search levels, and selecting elements to scrape.
+
 Usage:
     python xml_bundle_scraper.py <directorypath> <pattern>
         [--elements-file ELEMENTS_FILE]
@@ -14,6 +15,7 @@ Usage:
         [--clean-header-field-names]
         [--extra-file-info EXTRA_FILE_INFO]
         [--config-file CONFIG_FILE]
+
 Arguments:
     directorypath        The path to the directory containing the bundle to scrape.
     pattern              The glob pattern(s) (which may include wildcards like *, ?,
@@ -37,6 +39,7 @@ Arguments:
                          specified separated by spaces.
     --config-file CONFIG_FILE
                          An optional .ini configuration file for further customization.
+
 Example:
 python3 pds4_create_xml_index.py <toplevel_directory> "glob_path1" "glob_path2" 
 --output_file <outputfile> --elements-file sample_elements.txt --verbose
@@ -194,10 +197,10 @@ def process_tags(label_results, key, root, namespaces, prefixes):
 
     Inputs:
         label_results    A dictionary containing XML data to be processed.
-        key            The key representing the XML tag to be processed.
-        root           The root element of the XML tree.
-        namespaces     A dictionary containing XML namespace mappings.
-        prefixes       A dictionary containing XML namespace prefixes.
+        key              The key representing the XML tag to be processed.
+        root             The root element of the XML tree.
+        namespaces       A dictionary containing XML namespace mappings.
+        prefixes         A dictionary containing XML namespace prefixes.
     """
     key_new = convert_header_to_xpath(root, key, namespaces)
     for namespace in prefixes.keys():
@@ -468,8 +471,8 @@ def main():
                              'included.')
 
     parser.add_argument('--disambiguate-xpaths', action='store_true',
-                        help='If specified, use full XPaths in the column '
-                             'headers. If not specified, use only elements tags.')
+                        help='If specified, uses tags of unique XPaths. Any values with '
+                             'duplicate values will still use their full XPath.')
 
     parser.add_argument('--output-file', type=str,
                         help='The output filepath ending with your chosen filename for '

--- a/test_files/elements_file_success.csv
+++ b/test_files/elements_file_success.csv
@@ -1,0 +1,2 @@
+/pds:Product_Observational/pds:Identification_Area[1]/pds:logical_identifier[1],/pds:Product_Observational/pds:Identification_Area[1]/pds:version_id[1],/pds:Product_Observational/pds:Identification_Area[1]/pds:title[1]
+urn:nasa:pds:cassini_iss_saturn:data_raw:1455200455n,1.0,Cassini ISS Image 1455200455n.img

--- a/test_files/tester_config.ini
+++ b/test_files/tester_config.ini
@@ -1,0 +1,17 @@
+[pds:ASCII_Integer]
+inapplicable=-9999
+missing=-9988
+unknown=-9977
+anticipated=-9966
+
+[pds:ASCII_Real]
+inapplicable=-9999.0
+missing=-9988.0
+unknown=-9977.0
+anticipated=-9966.0
+
+[pds:ASCII_Short_String_Collapsed]
+inapplicable=inapplicable_alt
+missing=missing_alt
+unknown=unknown_alt
+anticipated=anticipated_alt

--- a/test_files/tester_label_1.xml
+++ b/test_files/tester_label_1.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Product_Observational
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="
+  http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.xsd
+  http://pds.nasa.gov/pds4/disp/v1 https://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.xsd
+  http://pds.nasa.gov/pds4/mission/cassini/v1 https://pds.nasa.gov/pds4/mission/cassini/v1/PDS4_CASSINI_1B00_1300.xsd">
+    <Identification_Area>
+        <logical_identifier>urn:nasa:pds:cassini_iss_saturn:data_raw:1455200455n</logical_identifier>
+        <version_id>1.0</version_id>
+        <title>Cassini ISS Image 1455200455n.img</title>
+        <information_model_version>1.11.0.0</information_model_version>
+    </Identification_Area>
+    <Observing_System>
+        <name>Cassini Orbiter Imaging Science Subsystem</name>
+        <Observing_System_Component>
+            <name>Cassini Orbiter</name>
+            <type>Spacecraft</type>
+            <Internal_Reference>
+                <lid_reference>urn:nasa:pds:context:instrument_host:spacecraft.co</lid_reference>
+                <reference_type>is_instrument_host</reference_type>
+            </Internal_Reference>
+        </Observing_System_Component>
+    </Observing_System>
+    <File_Area_Observational>
+    </File_Area_Observational>
+</Product_Observational>

--- a/tests/test_pds4_create_xml_index.py
+++ b/tests/test_pds4_create_xml_index.py
@@ -1,0 +1,161 @@
+import pandas as pd
+from pathlib import Path
+import pytest
+import os
+import sys
+sys.path.append(str(Path(__file__).resolve().parent.parent / Path("pds4indextools")))
+import pds4_create_xml_index as tools
+import tempfile
+
+
+def test_elements_file():
+    # Get the path to the test_files directory
+    root_dir = Path(__file__).resolve().parent.parent
+    test_files_dir = root_dir / 'test_files'
+    # THE PATH TO THE GOLDEN COPY
+    golden_file = str(test_files_dir / 'elements_file_success.csv')
+    new_file = 'elements_file.csv'
+
+    # Create a temporary directory in the same location as the test_files directory
+    with tempfile.TemporaryDirectory(dir=test_files_dir.parent) as temp_dir:
+        temp_dir_path = Path(temp_dir)
+        
+        # THE PATH TO THE NEW FILE
+        path_to_file = temp_dir_path / new_file
+
+        cmd_line = [
+            str(test_files_dir),
+            'tester_label_1.xml',
+            '--elements-file',
+            str(root_dir / 'samples/sample_elements.txt'),  
+            '--output-file',
+            str(path_to_file)
+        ]
+
+        # Call main() function with the simulated command line arguments
+        tools.main(cmd_line)
+
+        # Assert that the file now exists
+        assert os.path.isfile(path_to_file)
+
+        # Open and compare the two files
+        with open(path_to_file, 'rb') as created:
+            formed = created.read()
+
+        with open(golden_file, 'rb') as new:
+            expected = new.read()
+
+        assert formed == expected
+    
+
+def test_load_config_object():
+    config_object = tools.load_config_file(None)
+
+    assert config_object['pds:ASCII_Date_Time_YMD_UTC']['inapplicable'] == '0001-01-01T12:00Z'
+    assert config_object['pds:ASCII_Date_Time_YMD_UTC']['missing'] == '0002-01-01T12:00Z'
+    assert config_object['pds:ASCII_Date_Time_YMD_UTC']['unknown'] == '0003-01-01T12:00Z'
+    assert config_object['pds:ASCII_Date_Time_YMD_UTC']['anticipated'] == '0004-01-01T12:00Z'
+
+    assert config_object['pds:ASCII_Date_Time_YMD']['inapplicable'] == '0001-01-01T12:00'
+    assert config_object['pds:ASCII_Date_Time_YMD']['missing'] == '0002-01-01T12:00'
+    assert config_object['pds:ASCII_Date_Time_YMD']['unknown'] == '0003-01-01T12:00'
+    assert config_object['pds:ASCII_Date_Time_YMD']['anticipated'] == '0004-01-01T12:00'
+
+    assert config_object['pds:ASCII_Date_YMD']['inapplicable'] == '0001-01-01'
+    assert config_object['pds:ASCII_Date_YMD']['missing'] == '0002-01-01'
+    assert config_object['pds:ASCII_Date_YMD']['unknown'] == '0003-01-01'
+    assert config_object['pds:ASCII_Date_YMD']['anticipated'] == '0004-01-01'
+
+    assert config_object['pds:ASCII_Integer']['inapplicable'] == '-999'
+    assert config_object['pds:ASCII_Integer']['missing'] == '-998'
+    assert config_object['pds:ASCII_Integer']['unknown'] == '-997'
+    assert config_object['pds:ASCII_Integer']['anticipated'] == '-996'
+
+    assert config_object['pds:ASCII_Real']['inapplicable'] == '-999.0'
+    assert config_object['pds:ASCII_Real']['missing'] == '-998.0'
+    assert config_object['pds:ASCII_Real']['unknown'] == '-997.0'
+    assert config_object['pds:ASCII_Real']['anticipated'] == '-996.0'
+
+    assert config_object['pds:ASCII_Short_String_Collapsed']['inapplicable'] == 'inapplicable'
+    assert config_object['pds:ASCII_Short_String_Collapsed']['missing'] == 'missing'
+    assert config_object['pds:ASCII_Short_String_Collapsed']['unknown'] == 'unknown'
+    assert config_object['pds:ASCII_Short_String_Collapsed']['anticipated'] == 'anticipated'
+
+
+    # Tests that the config_object is loaded over. 
+    config_object = tools.load_config_file("../test_files/tester_config.ini")
+
+    assert config_object['pds:ASCII_Date_YMD']['inapplicable'] == '0001-01-01'
+    assert config_object['pds:ASCII_Date_YMD']['missing'] == '0002-01-01'
+    assert config_object['pds:ASCII_Date_YMD']['unknown'] == '0003-01-01'
+    assert config_object['pds:ASCII_Date_YMD']['anticipated'] == '0004-01-01'
+
+    assert config_object['pds:ASCII_Integer']['inapplicable'] == '-9999'
+    assert config_object['pds:ASCII_Integer']['missing'] == '-9988'
+    assert config_object['pds:ASCII_Integer']['unknown'] == '-9977'
+    assert config_object['pds:ASCII_Integer']['anticipated'] == '-9966'
+
+    assert config_object['pds:ASCII_Real']['inapplicable'] == '-9999.0'
+    assert config_object['pds:ASCII_Real']['missing'] == '-9988.0'
+    assert config_object['pds:ASCII_Real']['unknown'] == '-9977.0'
+    assert config_object['pds:ASCII_Real']['anticipated'] == '-9966.0'
+
+    assert config_object['pds:ASCII_Short_String_Collapsed']['inapplicable'] == 'inapplicable_alt'
+    assert config_object['pds:ASCII_Short_String_Collapsed']['missing'] == 'missing_alt'
+    assert config_object['pds:ASCII_Short_String_Collapsed']['unknown'] == 'unknown_alt'
+    assert config_object['pds:ASCII_Short_String_Collapsed']['anticipated'] == 'anticipated_alt'
+
+
+# now, a bad config file
+    with pytest.raises(SystemExit):
+        with pytest.raises(OSError):
+            tools.load_config_file("non_existent_file.ini")
+
+
+def test_default_value_for_nil():
+    config_object = tools.load_config_file(None)
+    integer = 'pds:ASCII_Integer'
+    double_float = 'pds:ASCII_Real'
+
+    assert config_object['pds:ASCII_Integer']['inapplicable'] == '-999'
+    assert tools.default_value_for_nil(config_object, integer, 'inapplicable') == -999
+    assert config_object['pds:ASCII_Integer']['missing'] == '-998'
+    assert tools.default_value_for_nil(config_object, integer, 'missing') == -998
+    assert config_object['pds:ASCII_Integer']['unknown'] == '-997'
+    assert tools.default_value_for_nil(config_object, integer, 'unknown') == -997
+    assert config_object['pds:ASCII_Integer']['anticipated'] == '-996'
+    assert tools.default_value_for_nil(config_object, integer, 'anticipated') == -996
+
+
+    assert config_object['pds:ASCII_Real']['inapplicable'] == '-999.0'
+    assert tools.default_value_for_nil(config_object, double_float, 'inapplicable') == -999.0
+    assert config_object['pds:ASCII_Real']['missing'] == '-998.0'
+    assert tools.default_value_for_nil(config_object, double_float, 'missing') == -998.0
+    assert config_object['pds:ASCII_Real']['unknown'] == '-997.0'
+    assert tools.default_value_for_nil(config_object, double_float, 'unknown') == -997.0
+    assert config_object['pds:ASCII_Real']['anticipated'] == '-996.0'
+    assert tools.default_value_for_nil(config_object, double_float, 'anticipated') == -996.0
+
+
+
+def test_split_into_elements():
+    xpath = '/pds:Product_Observational/pds:Observation_Area[1]/pds:Observing_System[1]/pds:name[1]'
+    pieces = tools.split_into_elements(xpath)
+    assert pieces == ('pds:Observation_Area', 'pds:Observing_System', 'pds:name')
+
+
+
+def test_process_schema_location():
+    test_files_dir = Path(__file__).resolve().parent.parent / 'test_files'
+    label_file = 'tester_label_1.xml'
+    schema_files = tools.process_schema_location(test_files_dir / label_file)
+    assert schema_files[0] == 'https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.xsd'
+    assert schema_files[1] == 'https://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.xsd'
+    assert schema_files[2] == 'https://pds.nasa.gov/pds4/mission/cassini/v1/PDS4_CASSINI_1B00_1300.xsd'
+
+
+
+
+
+# root_dir = Path(__file__).resolve().parent.parent
+# print(root_dir)


### PR DESCRIPTION
This pull request does the following:

- All headers in the resulting index file are now `XPaths`
- `--xpaths` is now `--disambiguate-xpaths`. Any unique `XPaths` will be changed into a shortened version.
- Information within the index file is no longer missed due to duplicate generalized `XPaths`
- New function: `grab_elements()`, for your `XPath` comparison needs. Returns a tuple of the element names in the order they appear in the `XPath`.
- covert_xpath_to_tag has been removed, since it's functionality is no longer needed.
- New function: `renumber_xpaths()`, which replaces the numbering in the XPaths to represent their occurrence rather than their hierarchy within the label file.