### PR TITLE
Bug Fixes for Several Issues

### DIFF
--- a/pds4indextools/pds4_create_xml_index.py
+++ b/pds4indextools/pds4_create_xml_index.py
@@ -1358,7 +1358,10 @@ def main(cmd_line=None):
                     item = item.replace(
                         ':', '_').replace('/', '__').replace('<', '_').replace('>', '')
                 output_fp.write("%s\n" % item)
-        print(f'XPath headers file generated at {output_txt_path}')
+        print(f'XPath headers file generated at {output_txt_path}.')
+        if not args.output_index_file:
+            print('No index file generated because --output-headers-file was '
+                  'provided without --output-index-file')
 
     # Generates the label for this index file, if --generate-label is used.
 
@@ -1373,7 +1376,13 @@ def main(cmd_line=None):
 
         # In this case, this filename is the filename of the index file previously
         # generated.
-        filename = str(Path(index_file).stem)
+        try:
+            filename = str(Path(index_file).stem)
+        except TypeError:
+            print('Label not generated. The "--output-index-file" argument is '
+                  'required to generate the label file.')
+
+            sys.exit(1)
 
         header_info = []
         sniffer = csv.Sniffer()
@@ -1475,8 +1484,12 @@ def main(cmd_line=None):
 
         if args.generate_label[0] == 'Product_Ancillary':
             label_content['Product_Ancillary'] = True
-        else:
+        elif args.generate_label[0] == 'Product_Metadata_Supplemental':
             label_content['Product_Metadata_Supplemental'] = True
+        else:
+            print(f'"{args.generate_label[0]}" is not an accepted value. Must be '
+                  f'"Product_Ancillary" or "Product_Metadata_Supplemental".')
+            sys.exit(1)
 
         if args.fixed_width:
             label_content['Table_Character'] = True

--- a/pds4indextools/pds4_create_xml_index.py
+++ b/pds4indextools/pds4_create_xml_index.py
@@ -1126,8 +1126,7 @@ def main(cmd_line=None):
                                   type=lambda x: validate_label_type(x,
                                                                      valid_label_types),
                                   nargs=1,
-                                  metavar='{Product_Ancillary, '
-                                          'Product_Metadata_Supplemental}',
+                                  metavar='{ancillary, metadata}',
                                   help='Generate a PDS4 label for the generated index '
                                        'file called "<output_index_file>.xml". '
                                        'Can generate either a Product_Ancillary or '


### PR DESCRIPTION
1. There was a bug that did not check the given value for `--generate-label`. Now there is a check, and if that value is not either `Product_Ancillary` or `Product_Metadata_Supplemental`, it will print a statement and exit:

```
(.venv) emiliesimpson@Emilies-MBP rms-pds4indextools % python pds4indextools/pds4_create_xml_index.py test_files/labels 'tester_label_1.xml' --output-headers-file headers.txt --output-index-file index.csv --generate-label Product_Anci

Index file generated at index.csv
XPath headers file generated at headers.txt.
"Product_Anci" is not an accepted value. Must be "Product_Ancillary" or "Product_Metadata_Supplemental".
```



2. It was not clear that when a user chooses `--output-headers-file` and does not include `--output-index-file`, the program will not generate an index file. A new statement will print if `--output-index-file` is not used with `--output-headers-file`.

```
(.venv) emiliesimpson@Emilies-MBP rms-pds4indextools % python pds4indextools/pds4_create_xml_index.py test_files/labels 'tester_label_1.xml' --output-headers-file headers.txt 
XPath headers file generated at headers.txt.
No index file generated because --output-headers-file was provided without --output-index-file
```



3. If a user chooses `--output-headers-file`, and then attempts to create a label file using `--generate-label`, there will now be a printed statement clarifying that you must include `--output-index-file` in the query for label generation to work:

```
(.venv) emiliesimpson@Emilies-MBP rms-pds4indextools % python pds4indextools/pds4_create_xml_index.py test_files/labels 'tester_label_1.xml' --output-headers-file headers.txt --generate-label Product_Ancillary 
XPath headers file generated at headers.txt.
No index file generated because --output-headers-file was provided without --output-index-file.
Label not generated. The "--output-index-file" argument is required to generate the label file.
```

- Fixes #16
- Fixes #17 
- Fixes #18 