### PR TITLE
Add documentation. Add entry point installation.

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -1,0 +1,37 @@
+name: Publish to PyPI
+run-name: "Publish to PyPI: ${{ github.ref_type }} ${{ github.ref_name }}"
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  upload_pypi:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -r requirements.txt
+
+      - name: Test
+        run: |
+          python -m pytest
+
+      - name: Build
+        run: |
+          python3 -m pip install --upgrade build && python3 -m build
+
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish_to_test_pypi.yml
+++ b/.github/workflows/publish_to_test_pypi.yml
@@ -1,0 +1,39 @@
+name: Publish to Test PyPI
+run-name: "Publish to Test PyPI: ${{ github.ref_type }} ${{ github.ref_name }}"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  upload_pypi:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -r requirements.txt
+
+      - name: Test
+        run: |
+          python -m pytest
+
+      - name: Build
+        run: |
+          python3 -m pip install --upgrade build && python3 -m build
+
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
+          verify-metadata: false

--- a/README.md
+++ b/README.md
@@ -1,128 +1,94 @@
-# rms-pds4indextools
+[![GitHub release; latest by date](https://img.shields.io/github/v/release/SETI/rms-pds4indextools)](https://github.com/SETI/rms-pds4indextools/releases)
+[![GitHub Release Date](https://img.shields.io/github/release-date/SETI/rms-pds4indextools)](https://github.com/SETI/rms-pds4indextools/releases)
+[![Test Status](https://img.shields.io/github/actions/workflow/status/SETI/rms-pds4indextools/run-tests.yml?branch=main)](https://github.com/SETI/rms-pds4indextools/actions)
+[![Documentation Status](https://readthedocs.org/projects/rms-pds4indextools/badge/?version=latest)](https://rms-pds4indextools.readthedocs.io/en/latest/?badge=latest)
+[![Code coverage](https://img.shields.io/codecov/c/github/SETI/rms-pds4indextools/main?logo=codecov)](https://codecov.io/gh/SETI/rms-pds4indextools)
+<br />
+[![PyPI - Version](https://img.shields.io/pypi/v/rms-pds4indextools)](https://pypi.org/project/rms-pds4indextools)
+[![PyPI - Format](https://img.shields.io/pypi/format/rms-pds4indextools)](https://pypi.org/project/rms-pds4indextools)
+[![PyPI - Downloads](https://img.shields.io/pypi/dm/rms-pds4indextools)](https://pypi.org/project/rms-pds4indextools)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/rms-pds4indextools)](https://pypi.org/project/rms-pds4indextools)
+<br />
+[![GitHub commits since latest release](https://img.shields.io/github/commits-since/SETI/rms-pds4indextools/latest)](https://github.com/SETI/rms-pds4indextools/commits/main/)
+[![GitHub commit activity](https://img.shields.io/github/commit-activity/m/SETI/rms-pds4indextools)](https://github.com/SETI/rms-pds4indextools/commits/main/)
+[![GitHub last commit](https://img.shields.io/github/last-commit/SETI/rms-pds4indextools)](https://github.com/SETI/rms-pds4indextools/commits/main/)
+<br />
+[![Number of GitHub open issues](https://img.shields.io/github/issues-raw/SETI/rms-pds4indextools)](https://github.com/SETI/rms-pds4indextools/issues)
+[![Number of GitHub closed issues](https://img.shields.io/github/issues-closed-raw/SETI/rms-pds4indextools)](https://github.com/SETI/rms-pds4indextools/issues)
+[![Number of GitHub open pull requests](https://img.shields.io/github/issues-pr-raw/SETI/rms-pds4indextools)](https://github.com/SETI/rms-pds4indextools/pulls)
+[![Number of GitHub closed pull requests](https://img.shields.io/github/issues-pr-closed-raw/SETI/rms-pds4indextools)](https://github.com/SETI/rms-pds4indextools/pulls)
+<br />
+![GitHub License](https://img.shields.io/github/license/SETI/rms-pds4indextools)
+[![Number of GitHub stars](https://img.shields.io/github/stars/SETI/rms-pds4indextools)](https://github.com/SETI/rms-pds4indextools/stargazers)
+![GitHub forks](https://img.shields.io/github/forks/SETI/rms-pds4indextools)
 
-Supported versions: Python >= 3.8
+# Introduction
 
-# PDS Ring-Moon Systems Node, SETI Institute
+`pds4indextools` is a set of programs and modules for parsing PDS4 XML labels.
+They were created and are maintained by the [Ring-Moon Systems Node](https://pds-rings.seti.org)
+of NASA's [Planetary Data System (PDS)](https://pds.nasa.gov).
 
-# `pds4indextools` MODULE OVERVIEW
+The following tools are currently available:
 
-The PDS4 Indexing Tool (`pds4indextools`) is a Python module designed to 
-facilitate the extraction and indexing of information from Planetary Data System
-(PDS) label files. This tool automates the process of parsing specified 
-directories for label files, extracting user-defined elements using XPath 
-expressions, and generating organized output files. Users can customize the 
-extraction process through various options, such as filtering content, 
-sorting output, and integrating additional file metadata. The tool supports 
-flexibility with configuration files and provides a straightforward interface 
-for creating both CSV-based index files and text files listing available XPath 
-headers. Whether for scientific research, data management, or archival purposes, 
-the PDS4 Indexing Tool offers a robust solution for efficiently managing and 
-accessing structured data within PDS-compliant datasets.
+- [`pds4_create_xml_index`](https://rms-pds4indextools.readthedocs.io/en/latest/pds4_create_xml_index.html):
+  A command-line program to scrape information from a series of PDS4 XML labels, usually
+  in a single collection, and generate a summary index file.
 
-`pds4indextools` may be installed by running `pip install pds4indextools`.
+# Installation
 
-Python versions 3.9 thru 3.12 are currently supported, with pre-built wheels
-available for Linux, MacOS, and Windows.
+`pds4indextools` is available via the `rms-pds4indextools` package on PyPI and
+can be installed with:
 
-# `XPath` SYNTAX AND STRUCTURE
+```sh
+pip install rms-pds4indextools
+```
 
-Before using the tool, it is imperative that the user becomes comfortable with 
-the XPath language, and how it is parsed with `lxml`.
+Note that this will install `pds4indextools` into your current system Python, or into your
+currently activated virtual environment (venv), if any. You may also install using `pipx`,
+which will isolate the installation from your system Python without requiring the creation
+of a virtual environment. To install `pipx`, please see the [installation
+instructions](https://pipx.pypa.io/stable/installation/). Once `pipx` is available, you
+may install `pds4indextools` with:
 
-When elements are scraped from a label, they are returned in a format akin to a
-filepath. The absolute XPath contains all parent elements up to the root element
-of the label. Each element after a certain depth can also contain predicates: 
-numbers surrounded by square brackets. These predicates give information on the
-location of the element in the label file, in relation to surrounding elements.
+```sh
+pipx install rms-pds4indextools
+```
 
-However, this module returns XPath headers that have been reformatted from XPath
-syntax.
+# Getting Started With `pds4_create_xml_index`
 
-- Namespaces are replaced by their prefixes. Namespaces are URIs that identify
-  which schema an element belongs to. For readability, the full URI's are
-  replaced by their prefixes.
+Once `pds4indextools` has been installed, you may access the `pds4_create_index_tools`
+program directly from the command line.
 
-- Square brackets are replaced by angled brackets. This module utilizes `glob`
-  syntax for finding label files and filtering out elements/attributes. Because
-  square brackets have meaning within `glob` statements, they needed to be
-  replaced with angled brackets. 
+The simplest use scrapes all XML labels from a collection and generates an index file:
 
-- The values within the predicates have been renumbered. In XPath syntax,
-  predicates are used to determine the location of an element in relation to its
-  parent. While this is useful in other applications, this logic fails if
-  multiples of the element and its parent appear within the document. Even if
-  the elements all have different values, all of their XPaths would be the same.
-  Instead, the predicates are renumbered to reflect which instance of the
-  element the value is represented by.
+```sh
+pds4_create_xml_index <collection_dir> "**/*.xml"
+```
 
-# SETUP
+Many options are available to customize the scraping and generation process, including
+limiting which XML elements are scrape, changing the format of the resulting index file,
+and generating a PDS4-compliant label. A summary of available options is available
+by typing:
 
-After using `pip install pds4indextools`, you can start planning where you would
-like to run the module from. While the module can run from anywhere, it is
-important to know where you plan to scrape the labels. This way you can avoid
-either producing an empty output file, or a file containing incorrect contents.
+```sh
+pds4_create_xml_index --help
+```
+
+Complete documentation is available [here](https://rms-pds4indextools.readthedocs.io/en/latest/pds4_create_xml_index.html)
 
 
-# COMMAND-LINE ARGUMENTS
+# Contributing
 
-This module uses command-line arguments to create and tailor the contents and
-format of your output file.
+Information on contributing to this package can be found in the
+[Contributing Guide](https://github.com/SETI/rms-pds4indextools/blob/main/CONTRIBUTING.md).
 
-`REQUIRED COMMAND-LINE ARGUMENTS -- LABEL LOCATION AND NOMENCLATURE`
-- directorypath: The topmost level directory you want to navigate. This is the 
-  starting point where the code will look for matching labels.
+# Links
 
-- patterns: The glob pattern(s) that will be used to find label files under the
-  given directorypath. The directorypath combined with these patterns should
-  form a complete filepath. `glob` wildcard symbols, such as `*`, `?`, and `**`,
-  are allowed. Surround each pattern with quotes. If the user wants to specify
-  multiple patterns, separate with spaces.
+- [Documentation](https://rms-pds4indextools.readthedocs.io)
+- [Repository](https://github.com/SETI/rms-pds4indextools)
+- [Issue tracker](https://github.com/SETI/rms-pds4indextools/issues)
+- [PyPi](https://pypi.org/project/rms-pds4indextools)
 
-`REQUIRED COMMAND-LINE ARGUMENTS -- OUTPUT FILE FORMAT`
-- output-csv-file: Specify the location and filename of the index file. This
-  file will contain the extracted information organized in CSV format.
+# Licensing
 
-- output-txt-file: Specify the location and filename of the XPath headers file.
-  This file will contain a list of available XPaths extracted from the label
-  files.
-
-`OPTIONAL COMMAND-LINE ARGUMENTS -- CUSTOMIZATION`
-- elements-file: Optional. Specify a text file containing a list of specific
-  elements or XPaths to extract from the label files. If not specified, all
-  elements found in the label files will be included.
-
-- simplify-xpaths: Optional. If specified, the output will only include unique
-  XPaths with simplified tags. Duplicate values will still use their full XPath.
-
-- verbose: Optional. Activate verbose mode to display detailed information
-  during the file scraping process.
-
-- sort-by: Optional. Specify one or more columns to sort the index file.
-  Columns can be identified by either the full XPath header or the simplified
-  version if `--simplify-xpaths` is used. Use `--dump-available-xpaths` to see
-  all available sorting options.
-
-- clean-header-field-names: Optional. If specified, column headers will be
-  renamed to use only characters permissible in variable names, making them
-  more compatible with certain systems.
-
-- add-extra-file-info: Optional. Add additional columns to the final index file.
-  Choose from "LID", "filename", "filepath", "bundle_lid", and "bundle". Specify
-  multiple values as separate arguments separated by spaces.
-
-- config-file: Optional. Specify a `.ini` configuration file for further
-  customization of the extraction process.
-
-- dump-available-xpaths: Optional. Generates a `.txt` file containing all
-  available XPaths within the given label files. This file can serve as a base
-  file for `--elements-file` if modified.
-
-- fixed-width: Optional. If specified, the index file will be formatted with
-  fixed-width columns.
-
-- generate-label: Optional. Specify the type of PDS4 label to generate for the
-  index file. Choose either "Product_Ancillary" or
-  "Product_Metadata_Supplemental".
-
-- label-user-input: Optional. Provide an optional `.yaml` file containing
-  additional information for the generated PDS4 label.
+This code is licensed under the [Apache License v2.0](https://github.com/SETI/rms-pds4indextools/blob/main/LICENSE).

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,32 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('..'))
+
+project = 'pds4indextools'
+copyright = '2024, PDS Ring-Moon Systems Node'
+author = 'PDS Ring-Moon Systems Node'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = ['myst_parser', 'sphinx.ext.autodoc', 'sphinx.ext.napoleon',
+              'sphinx.ext.viewcode']
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,25 @@
+.. solar documentation master file, created by
+   sphinx-quickstart on Fri May 24 12:58:54 2024.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to ``pds4indextools``'s documentation!
+==============================================
+
+.. include:: ../README.md
+   :parser: myst_parser.sphinx_
+   :start-after: forks/SETI/rms-pds4indextools)
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   pds4_create_xml_index
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/pds4_create_xml_index.rst
+++ b/docs/pds4_create_xml_index.rst
@@ -1,0 +1,203 @@
+``pds4_create_xml_index`` Program
+=================================
+
+The RMS Node's PDS4 Index Creation Tool (``pds4_create_xml_index``) is designed to
+facilitate the extraction and indexing of information from `Planetary Data System (PDS)
+<https://pds.nasa.gov>`_ `PDS4-format <https://pds.nasa.gov/datastandards/documents/>`_
+label files. This tool automates the process of parsing specified directories for label
+files, extracting user-defined elements using XPath expressions, and generating organized
+output files. Users can customize the extraction process through various options, such as
+filtering content, sorting output, and integrating additional file metadata. The tool
+supports flexibility with configuration files and provides a straightforward interface for
+creating both CSV-based (variable or fixed-width) index files and text files listing
+available XPath headers. Whether for scientific research, data management, or archival
+purposes, the PDS4 Index Creation Tool offers a robust solution for efficiently managing
+and accessing structured data within PDS4-compliant datasets.
+
+
+XPath Syntax and Structure
+--------------------------
+
+(FIXIT The next two paragraphs need to be rewritten becase the user *doesn't* need to
+learn ``lxml``, just the XPath format we provide. We should explain that in detail, with
+examples.)
+
+Before using the tool, it is imperative that the user becomes comfortable with
+the XPath language and how it is parsed with ``lxml``.
+
+When elements are scraped from a label, they are returned in a format akin to a
+filepath. The absolute XPath contains all parent elements up to the root element
+of the label. Each element after a certain depth can also contain predicates:
+numbers surrounded by square brackets. These predicates give information on the
+location of the element in the label file, in relation to surrounding elements.
+
+However, this module returns XPath headers that have been reformatted from XPath
+syntax.
+
+- Namespaces are replaced by their prefixes. Namespaces are URIs that identify
+  which schema an element belongs to. For readability, the full URI's are
+  replaced by their prefixes.
+
+- Square brackets are replaced by angled brackets. This module utilizes ``glob``
+  syntax for finding label files and filtering out elements/attributes. Because
+  square brackets have meaning within ``glob`` statements, they needed to be
+  replaced with angled brackets.
+
+- The values within the predicates have been renumbered. In XPath syntax,
+  predicates are used to determine the location of an element in relation to its
+  parent. While this is useful in other applications, this logic fails if
+  multiples of the element and its parent appear within the document. Even if
+  the elements all have different values, all of their XPaths would be the same.
+  Instead, the predicates are renumbered to reflect which instance of the
+  element the value is represented by.
+
+
+Command Line Arguments
+----------------------
+
+Required arguments
+^^^^^^^^^^^^^^^^^^
+
+Two command line arguments are required in every run.
+
+The first is the top-level directory of the collection, bundle, or other directory
+structure where the label files are location. All file path strings included in the index
+file and/or label will be given relative to this directory.
+
+The second is one or more ``glob``-style patterns that specify the filenames of the labels
+to be scraped. The patterns should be given relative to the top-level directory.
+``glob``-style patterns allow wildcard symbols similar to those used by most
+Unix shells:
+
+- ``?`` matches any single character within a directory or file name
+- ``*`` matches any series of characters within a directory or file name
+- ``**`` matches any filename or zero or more nested directories
+- ``[seq]`` matches any character in ``seq``
+- ``[!seq]`` matches any character not in ``seq``
+
+To avoid interpretation by the shell, all patterns must be surrounded by double quotes.
+If more than one pattern is specified, they should each be surrounded by double quotes
+and separated by spaces.
+
+Example::
+
+    pds4_create_xml_index /top/level/directory "data/planet/*.xml" "**/rings/*.xml"
+
+Optional arguments
+^^^^^^^^^^^^^^^^^^
+
+Index file generation
+"""""""""""""""""""""
+
+- ``--output-index-file INDEX_FILEPATH``: Specify the location and filename of the index
+  file. This file will contain the extracted information organized in CSV format. It is
+  recommended that the file have the suffix ``.csv``. If no directory is specified, the
+  index file will be written into the current directory. If this option is omitted
+  entirely, the default filename ``index.csv`` will be used. However, to prevent
+  accidentally overwriting an existing index file, if ``index.csv`` already exists in the
+  current directory, the index will be written into ``index1.csv``, ``index2.csv``, etc.
+  as necessary.
+
+- ``--add-extra-file-info COMMA_SEPARATED_COLUMN_NAMES``: Generate additional information
+  columns in the index file. One or more column names can be specified separated by
+  commas. The available column names are:
+
+  - ``filename``: The base filename of the label file.
+  - ``filepath``: The path of the label file relative to the top-level directory.
+  - ``bundle_lid``: The LID of the bundle containing the label file.
+  - ``bundle``: The name of the bundle containing the label file.
+
+- ``--sort-by COMMA_SEPARATED_HEADER_NAME(s)``: Sort the resulting index file by the value
+  in one or more columns. The column names are those that appear in the final index file,
+  as modified by ``--simplify-xpaths``, ``--limit-xpaths-file``, or
+  ``--clean-header-field-names``, and include any additional columns added with
+  ``--add-extra-file-info``. To see a list of available column names, use
+  ``--output-headers-file``. More than one sort key can be specified by separating them by
+  commas, in which case the sort proceeds hierarchically from left to right. As the XPath
+  syntax includes special characters that may be interpreted by the shell, it may be
+  necessary to surround the list of sort keys with double quotes.
+
+  Example::
+
+    pds4_create_xml_index <...> --sort-by "pds:Product_Observational/pds:Identification_Area<1>/pds:version_id<1>,pds:logical_identifier,"
+
+- ``--fixed-width``: Format the index file using fixed-width columns.
+
+- ``--clean-header-field-names``: Rename column headers to use only characters permissible
+  in variable names, making them more compatible with certain file readers.
+
+- ``--simplify-xpaths``: Where possible, rename column headers to use only the tag instead
+  of the full XPath. If this would cause ambiguity, leave the name using the full XPath
+  instead. This will usually produce an index file with simpler column names, potentially
+  making the file easier to display or use.
+
+Limiting results
+""""""""""""""""
+
+- ``--limit-xpaths-file XPATHS_FILEPATH``: Specify a text file containing a list of
+  specific XPaths to extract from the label files. If not specified, all elements found in
+  the label files will be included. The given text file can specify XPaths using
+  ``glob``-style syntax, where each XPath level is treated as if it were a directory in a
+  filesystem. Available wildcards are:
+
+  - ``?`` matches any single character within an XPath level
+  - ``*`` matches any series of characters within an XPath level
+  - ``**`` matches any tags and zero or more nested XPath levels
+  - ``[seq]`` matches any character in ``seq``
+  - ``[!seq]`` matches any character not in ``seq``
+
+  For example, the XPath ``pds:Product_Observational/pds:Identification_Area<1>/pds:version_id<1>``
+  could be matched using:
+
+  - ``pds:Product_Observational/pds:Identification_Area<1>/pds:version_id<1>``
+  - ``pds:Product_Observational/pds:Identification_Area<1>/*``
+  - ``pds:Product_Observational/**/*version*``
+  - ``pds:Product_Observational/**``
+
+  In addition, XPaths can be removed from the selected set by prefacing the pattern with ``!``.
+  For example, the following set of patterns would select all XPaths except for any
+  containing the string ``version`` somewhere in the name::
+
+    **
+    !**/*version*
+
+- ``--output-headers-file HEADERS_FILEPATH``: Write a list of all column names included in
+  the index file. The column names will precisely agree with those given in the first line
+  of the index file, as modified by ``--simplify-xpaths``, ``--limit-xpaths-file``, or
+  ``--clean-header-field-names``, and include any additional columns added with
+  ``--add-extra-file-info``. This file is useful to easily verify the contents of the
+  index file and also to serve as a starting point for a file to be supplied to
+  ``--limit-xpaths-file``.
+
+Label generation
+""""""""""""""""
+
+- ``--generate-label {ancillary,supplemental}``: Generate a label file describing the
+  index file. The label file will be placed in the same directory as the index file and
+  will have the same name except that the suffix will be ``.xml``. The required argument
+  specifies the type of metadata class to use in the label file, ``Product_Ancillary`` for
+  ``ancillary`` or ``Product_Metadata_Supplemental`` for ``supplemental``. Additional
+  customization of the label can be provided with ``--label-user-input``.
+
+- ``--label-user-info``: Provide a file containing customization of the generated label.
+  The file must be in YAML format.
+
+Miscellaneous
+"""""""""""""
+
+- ``--verbose``: Display detailed information during the file scraping process that may
+  be useful for debugging.
+
+- ``--config-file``: Specify a ``.ini``-style configuration file for further customization
+  of the extraction process.
+
+
+
+(FIXIT) ADDITIONAL THINGS TO DISCUSS
+------------------------------------
+
+- Explanation of how we format XPaths (e.g. what do the ``<1>``-style suffixes mean?)
+- Format and contents of the ``--config-file`` config file including discussion of
+  nillable elements.
+- Format and contents of the ``--label-user-file`` config file (and should these be the
+  same thing?)

--- a/pds4indextools/pds4_create_xml_index.py
+++ b/pds4indextools/pds4_create_xml_index.py
@@ -25,9 +25,18 @@ from pathlib import Path
 import platform
 import requests
 import sys
+import textwrap as _textwrap
 import yaml
 
 import pdstemplate as ps
+
+try:
+    from ._version import __version__
+except ImportError:  # pragma: nocover
+    try:
+        from _version import __version__
+    except ImportError:  # pragma: nocover
+        __version__ = 'Version unspecified'
 
 
 SplitXPath = namedtuple('SplitXPath',
@@ -1025,11 +1034,33 @@ def generate_unique_filename(base_name):
     return new_filename
 
 
+class MultilineFormatter(argparse.HelpFormatter):
+    """Class to allow multi-line help messages with argparse.
+
+    See details here:
+    https://stackoverflow.com/questions/3853722/how-to-insert-newlines-on-argparse-help-text
+    """
+    def _fill_text(self, text, width, indent):
+        text = self._whitespace_matcher.sub(' ', text).strip()
+        paragraphs = text.split('|n')
+        multiline_text = ''
+        for paragraph in paragraphs:
+            formatted_paragraph = _textwrap.fill(paragraph, width, initial_indent=indent,
+                                                 subsequent_indent=indent) + '\n'
+            multiline_text = multiline_text + formatted_paragraph
+        return multiline_text
+
+
 def main(cmd_line=None):
-    # FIXIT: CHANGE THIS LINK AFTER MERGED TO MAIN
+    epilog_sfx = ''
+    if __version__ != 'Version unspecified':
+        epilog_sfx = f'|nVersion: {__version__}'
     parser = argparse.ArgumentParser(
-        epilog="For more details, please visit the online documentation at: "
-        "https://github.com/SETI/rms-pds4indextools/blob/es-unit_tests/README.md"
+        formatter_class=MultilineFormatter,
+        description='Scrape a set of PDS4 XML labels, usually from a single collection, '
+                    'and produce a summary index file.',
+        epilog='For more details, please visit the online documentation at: '
+               'https://rms-pds4indextools.readthedocs.io/en/latest' + epilog_sfx
         )
 
     valid_add_extra_file_info = ['lid', 'filename', 'filepath', 'bundle_lid', 'bundle']
@@ -1055,7 +1086,7 @@ def main(cmd_line=None):
     index_file_generation.add_argument(
         '--add-extra-file-info',
         type=lambda x: validate_comma_separated_list(x, valid_add_extra_file_info),
-        metavar='COMMA_SEPARATED_COLUMN_NAMES',
+        metavar='COMMA_SEPARATED_COLUMN_NAME(s)',
         help='Add additional columns to the final index file. If specifying multiple '
              'column names, supply them as one argument separated by commas. Possible '
              'values include "lid", "filename", "filepath", "bundle_lid", and "bundle"')
@@ -1092,7 +1123,7 @@ def main(cmd_line=None):
                                        'the label files are included.')
 
     limiting_results.add_argument('--output-headers-file', type=str,
-                                  metavar='XPATHS_FILEPATH',
+                                  metavar='HEADERS_FILEPATH',
                                   help='Generate a file containing all possible headers '
                                        'after they have been optionally filtered and/or '
                                        'simplified.')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,9 @@ requires-python = ">=3.8"
 dependencies = [
     "lxml",
     "pandas",
-    "requests"
+    "pyyaml",
+    "requests",
+    "rms-pdstemplate"
 ]
 license = {text = "Apache-2.0"}
 maintainers = [
@@ -38,9 +40,13 @@ classifiers = [
 
 [project.urls]
 Homepage = "https://github.com/SETI/rms-pds4indextools"
+Documentation = "https://rms-textkernel.readthedocs.io/en/latest"
 Repository = "https://github.com/SETI/rms-pds4indextools"
 Source = "https://github.com/SETI/rms-pds4indextools"
 Issues = "https://github.com/SETI/rms-pds4indextools/issues"
+
+[project.scripts]
+pds4_create_xml_index = "pds4indextools.pds4_create_xml_index:main"
 
 [tool.setuptools]
 packages = ["pds4indextools"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,12 @@
 coverage
 flake8
 lxml
+myst-parser
 pandas
 pytest
 pyyaml
 requests
 rms-pdstemplate
+sphinx
+sphinxcontrib-napoleon
+sphinx-rtd-theme


### PR DESCRIPTION
- Fixes #11 
- Fixes #13 

**Support PyPI-based installation by a user:**

- Add "Publish to PyPI" (triggered by a GitHub release) and "Publish to Test PyPI" (triggered manually) GitHub actions. 
  - Neither of these can be tested until after this pull is merged so further changes may be required.
  - After this pull is merged they will each need to be triggered and the appropriate PyPI administrative work done, including adding the appropriate SECRET tokens to this repo. (@rfrenchseti will do this)
- Add `main` entry point for `pds4_create_xml_index.py` in `pyproject.toml`.

To test installation, open a terminal that is unrelated to this project and:

```sh
cd <some temporary directory>
python3 -m venv venv
source venv/bin/activate
pip install <dir>/rms-pds4indextools
```

At this point you should be able to type:

```sh
pds4_create_xml_index --help
```

**Add documentation:**

- Modify `README.md` to follow our standard format and remove most information on how to run `pds4_create_xml_index`.
- Add a `docs` directory supporting Sphinx.
- Update `requirements.txt` to support Sphinx.
- Update Sphinx documentation to include the original contents of `README.md`, now converted to RST format, and updated to show current command line options and also fleshed out with more details and examples.
- Further review and work on the documentation is required, and several areas are marked with FIXIT tags.
- To build the documentation (required after every change to a `.rst` file):

```sh
cd docs
make html
```

- To view the built documentation, use your file browser to go to `<dir>/rms-pds4indextools/docs/_build/html` and double-click on the `index.html` file. Then view the docs in your browser window.
- For information on formatting documentation in RST format, see https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
- As soon as this pull is merged, I will install the necessary hooks for it to generate web pages for readthedocs automatically.

**Miscellaneous**

- Minor changes to argparse help messages.
- Added new class `MultilineFormatter` which allows hard newlines to be placed in help strings for better formatting.
