### PR TITLE
Fixing documentation, adding explanatory comments to unit tests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,5 @@
 [flake8]
 max-line-length: 90
+per-file-ignores =
+    # line too long
+    tests/test_pds4_create_xml_index_blackbox.py: E501

--- a/docs/pds4_create_xml_index.rst
+++ b/docs/pds4_create_xml_index.rst
@@ -23,14 +23,16 @@ hierarchy in a manner similar to `the standard XPath format <https://developer.m
 While familiarity with XPath syntax is beneficial, it is not necessary to use this tool
 effectively. Note that for simplicity we call our headers XPaths throughout this document
 and within the command line arguments, despite some minor syntax differences. Below we
-describe the syntax we use for our headers. An XPath header is read from left to right,
-starting with the root element and moving through each subsequent child element. Each
-element in the path is separated by a forward slash (/). If an element has multiple
-instances within a single parent, predicates (numbers within angle brackets) are used to
-specify the exact instance, such as ../pds:Observation_Area<1>/pds:version_id<1>, which
-selects the first version_id element in Observation_Area. The predicate numbers count the
-instances of the child element, rather than its structural position in the file. For
-example, given the XML fragment:
+describe the syntax we use for our headers. 
+
+An XPath header is read from left to right, starting with the root element and moving 
+through each subsequent child element. Elements are separated by a forward slash (``/``).
+If an element has multiple instances within a single parent, predicates (numbers within
+angle brackets) are used to specify the exact instance, such as
+``../pds:Observation_Area<1>/pds:version_id<1>``, which selects the first ``version_id``
+element in ``Observation_Area``. The predicate numbers count the instances of the child
+element, rather than its structural position in the file. For example, given the XML
+fragment:
 
 ```
 <Product_Observational>
@@ -200,6 +202,7 @@ Miscellaneous
   of the extraction process. This file allows you to replace the field entry for any
   element's data type. Its primary purpose is to handle nilled elements. Nilled elements
   are elements that are intentionally omitted due to inapplicable, missing, unknown, or
-  anticipated values. The default configuration file (``pds4indextools.ini``) covers a
-  specific set of data types. Any additional data types can be covered using the specified
-  configuration file.
+  anticipated values. The following data types are automatically covered by the tool:
+  ``ASCII_Real``, ``ASCII_Integer``, ``ASCII_Short_String_Collapsed``, ``ASCII_Date_YMD``,
+  ``ASCII_Date_Time_YMD``, and ``ASCII_Date_Time_YMD_UTC``. Any additional data types can
+  be covered using the specified configuration file.

--- a/tests/test_pds4_create_xml_index_blackbox.py
+++ b/tests/test_pds4_create_xml_index_blackbox.py
@@ -18,10 +18,7 @@ labels_dir = test_files_dir / 'labels'
         'golden_file,new_file,cmd_line',
         [
             # Testing --limit-xpaths-file
-            # Executable command: pds4_create_xml_index ../test_files/labels
-            # "tester_label_1.xml" --limit-xpaths-file
-            # ../test_files/samples/element_1.txt --output-headers-file
-            # limit_xpaths_file.txt
+            # Executable command: pds4_create_xml_index ../test_files/labels "tester_label_1.xml" --limit-xpaths-file ../test_files/samples/element_1.txt --output-headers-file limit_xpaths_file.txt
             # Compare result to golden copy:
             # test_files/expected/limit_xpaths_file_success_1.txt
             (
@@ -36,10 +33,7 @@ labels_dir = test_files_dir / 'labels'
                 ]
             ),
 
-            # Executable command: pds4_create_xml_index ../test_files/labels
-            # "tester_label_2.xml" --limit-xpaths-file
-            # ../test_files/samples/element_2.txt --output-headers-file
-            # limit_xpaths_file_2.txt
+            # Executable command: pds4_create_xml_index ../test_files/labels "tester_label_2.xml" --limit-xpaths-file ../test_files/samples/element_2.txt --output-headers-file limit_xpaths_file_2.txt
             # Compare result to golden copy:
             # test_files/expected/limit_xpaths_file_success_2.txt
             (
@@ -54,10 +48,7 @@ labels_dir = test_files_dir / 'labels'
                 ]
             ),
 
-            # Executable command: pds4_create_xml_index ../test_files/labels
-            # "tester_label_2.xml" --limit-xpaths-file
-            # ../test_files/samples/element_duplicates.txt
-            # --output-headers-file elements_dupe_file_2.txt
+            # Executable command: pds4_create_xml_index ../test_files/labels "tester_label_2.xml" --limit-xpaths-file ../test_files/samples/element_duplicates.txt --output-headers-file elements_dupe_file_2.txt
             # Compare result to golden copy:
             # test_files/expected/limit_xpaths_file_success_2.txt
             (
@@ -72,10 +63,7 @@ labels_dir = test_files_dir / 'labels'
                 ]
             ),
 
-            # Executable command: pds4_create_xml_index ../test_files/labels
-            # "tester_label_2.xml" tester_label_3.xml" --limit-xpaths-file
-            # ../test_files/samples/element_3.txt --output-headers-file
-            # limit_xpaths_file_3.txt
+            # Executable command: pds4_create_xml_index ../test_files/labels "tester_label_2.xml" tester_label_3.xml" --limit-xpaths-file ../test_files/samples/element_3.txt --output-headers-file limit_xpaths_file_3.txt
             # Compare result to golden copy:
             # test_files/expected/limit_xpaths_file_success_3.txt
             (
@@ -91,10 +79,7 @@ labels_dir = test_files_dir / 'labels'
                 ]
             ),
 
-            # Executable command: pds4_create_xml_index ../test_files/labels
-            # "tester_label_1.xml" "tester_label_2.xml" "tester_label_3.xml"
-            # --limit-xpaths-file ../test_files/samples/element_4.txt
-            # --output-headers-file limit_xpaths_file_4.txt
+            # Executable command: pds4_create_xml_index ../test_files/labels "tester_label_1.xml" "tester_label_2.xml" "tester_label_3.xml" --limit-xpaths-file ../test_files/samples/element_4.txt --output-headers-file limit_xpaths_file_4.txt
             # Compare result to golden copy:
             # test_files/expected/limit_xpaths_file_success_4.txt
             (
@@ -112,9 +97,7 @@ labels_dir = test_files_dir / 'labels'
             ),
 
             # Testing --simplify-xpaths
-            # Executable command: pds4_create_xml_index ../test_files/labels
-            # "tester_label_1.xml" --simplify-xpaths
-            # --output-headers-file simplify_xpaths_1.txt
+            # Executable command: pds4_create_xml_index ../test_files/labels "tester_label_1.xml" --simplify-xpaths --output-headers-file simplify_xpaths_1.txt
             # Compare result to golden copy:
             # test_files/expected/simplify_xpaths_success_1.txt
             (
@@ -129,11 +112,7 @@ labels_dir = test_files_dir / 'labels'
             ),
 
             # Testing --simplify-xpaths
-            # Executable command: pds4_create_xml_index ../test_files/labels
-            # "tester_label_1.xml" "tester_label_2.xml" "tester_label_3.xml"
-            # --simplify-xpaths --limit-xpaths-file
-            # ../test_files/samples/elements_xpath_simplify_2.txt
-            # --output-headers-file simplify_xpaths_2.txt
+            # Executable command: pds4_create_xml_index ../test_files/labels "tester_label_1.xml" "tester_label_2.xml" "tester_label_3.xml" --simplify-xpaths --limit-xpaths-file ../test_files/samples/elements_xpath_simplify_2.txt --output-headers-file simplify_xpaths_2.txt
             # Compare result to golden copy:
             # test_files/expected/simplify_xpaths_success_2.txt
             (
@@ -152,10 +131,7 @@ labels_dir = test_files_dir / 'labels'
             ),
 
             # Testing --simplify-xpaths
-            # Executable command: pds4_create_xml_index ../test_files/labels
-            # "tester_label_2.xml" --simplify-xpaths --limit-xpaths-file
-            # ../test_files/samples/elements_xpath_simplify_3.txt
-            # --output-headers-file simplify_xpaths_3.txt
+            # Executable command: pds4_create_xml_index ../test_files/labels "tester_label_2.xml" --simplify-xpaths --limit-xpaths-file ../test_files/samples/elements_xpath_simplify_3.txt --output-headers-file simplify_xpaths_3.txt
             # Compare result to golden copy:
             # test_files/expected/simplify_xpaths_success_3.txt
             (
@@ -172,10 +148,7 @@ labels_dir = test_files_dir / 'labels'
             ),
 
             # Testing --simplify-xpaths
-            # Executable command: pds4_create_xml_index ../test_files/labels
-            # "tester_label_3.xml" --simplify-xpaths --limit-xpaths-file
-            # ../test_files/samples/elements_xpath_simplify_4.txt
-            # --output-headers-file simplify_xpaths_4.txt
+            # Executable command: pds4_create_xml_index ../test_files/labels "tester_label_3.xml" --simplify-xpaths --limit-xpaths-file ../test_files/samples/elements_xpath_simplify_4.txt --output-headers-file simplify_xpaths_4.txt
             # Compare result to golden copy:
             # test_files/expected/simplify_xpaths_success_4.txt
             (
@@ -192,10 +165,7 @@ labels_dir = test_files_dir / 'labels'
             ),
 
             # Testing --add-extra-file-info
-            # Executable command: pds4_create_xml_index ../test_files/labels
-            # "tester_label_2.xml" --limit-xpaths-file
-            # ../test_files/samples/element_1.txt --add-extra-file-info filename,filepath
-            # --output-index-file extra_file_info_1.csv
+            # Executable command: pds4_create_xml_index ../test_files/labels "tester_label_2.xml" --limit-xpaths-file ../test_files/samples/element_1.txt --add-extra-file-info filename,filepath --output-index-file extra_file_info_1.csv
             # Compare result to golden copy:
             # test_files/expected/extra_file_info_success_1.csv
             (
@@ -212,10 +182,7 @@ labels_dir = test_files_dir / 'labels'
                 ]
             ),
 
-            # Executable command: pds4_create_xml_index ../test_files/labels
-            # "tester_label_1.xml" "tester_label_2.xml" "tester_label_3.xml"
-            # --limit-xpaths-file ../test_files/samples/element_5.txt
-            # --add-extra-file-info filename --sort-by filename
+            # Executable command: pds4_create_xml_index ../test_files/labels "tester_label_1.xml" "tester_label_2.xml" "tester_label_3.xml" --limit-xpaths-file ../test_files/samples/element_5.txt --add-extra-file-info filename --sort-by filename
             # --output-index-file extra_file_info_2.csv
             # Compare result to golden copy:
             # test_files/expected/extra_file_info_success_2.csv
@@ -237,11 +204,7 @@ labels_dir = test_files_dir / 'labels'
                 ]
             ),
 
-            # Executable command: pds4_create_xml_index ../test_files/labels
-            # "tester_label_1.xml" "tester_label_2.xml" "tester_label_3.xml"
-            # --limit-xpaths-file ../test_files/samples/element_5.txt
-            # --add-extra-file-info filename,filepath,lid,bundle,bundle_lid
-            # --sort-by filename --output-index-file extra_file_info_3.csv
+            # Executable command: pds4_create_xml_index ../test_files/labels "tester_label_1.xml" "tester_label_2.xml" "tester_label_3.xml" --limit-xpaths-file ../test_files/samples/element_5.txt --add-extra-file-info filename,filepath,lid,bundle,bundle_lid --sort-by filename --output-index-file extra_file_info_3.csv
             # Compare result to golden copy:
             # test_files/expected/extra_file_info_success_3.csv
             (
@@ -263,9 +226,7 @@ labels_dir = test_files_dir / 'labels'
             ),
 
             # Testing --clean-header-field-names
-            # Executable command: pds4_create_xml_index ../test_files/labels
-            # "tester_label_1.xml" --clean-header-field-names
-            # --output-headers-file clean_header_field_names_1.txt
+            # Executable command: pds4_create_xml_index ../test_files/labels "tester_label_1.xml" --clean-header-field-names --output-headers-file clean_header_field_names_1.txt
             # Compare result to golden copy:
             # test_files/expected/clean_header_field_names_success_1.txt
             (
@@ -279,11 +240,7 @@ labels_dir = test_files_dir / 'labels'
                 ]
             ),
 
-            # Executable command: pds4_create_xml_index ../test_files/labels
-            # "tester_label_1.xml" "tester_label_1.xml" --limit-xpaths-file
-            # ../test_files/samples/elements_clean_header_field_names.txt
-            # --clean-header-field-names
-            # --output-headers-file clean_header_field_names_2.txt
+            # Executable command: pds4_create_xml_index ../test_files/labels "tester_label_1.xml" "tester_label_1.xml" --limit-xpaths-file ../test_files/samples/elements_clean_header_field_names.txt --clean-header-field-names --output-headers-file clean_header_field_names_2.txt
             # Compare result to golden copy:
             # test_files/expected/clean_header_field_names_success_2.txt
             (
@@ -301,12 +258,7 @@ labels_dir = test_files_dir / 'labels'
             ),
 
             # Testing --sort by
-            # Executable command: pds4_create_xml_index ../test_files/labels
-            # "tester_label_1.xml" "tester_label_2.xml" "tester_label_3.xml"
-            # --limit-xpaths-file
-            # ../test_files/samples/elements_clean_header_field_names.txt --sort-by
-            # 'pds:Product_Observational/pds:Identification_Area<1>/
-            #  pds:logical_identifier<1>' --output-index-file sort_by_1.csv
+            # Executable command: pds4_create_xml_index ../test_files/labels "tester_label_1.xml" "tester_label_2.xml" "tester_label_3.xml" --limit-xpaths-file ../test_files/samples/elements_clean_header_field_names.txt --sort-by 'pds:Product_Observational/pds:Identification_Area<1>/pds:logical_identifier<1>' --output-index-file sort_by_1.csv
             # Compare result to golden copy:
             # test_files/expected/sort_by_success_1.csv
             (
@@ -326,12 +278,7 @@ labels_dir = test_files_dir / 'labels'
                 ]
             ),
 
-            # Executable command: pds4_create_xml_index ../test_files/labels
-            # "tester_label_1.xml" "tester_label_2.xml" "tester_label_3.xml"
-            # --limit-xpaths-file
-            # ../test_files/samples/elements_clean_header_field_names.txt
-            # --add-extra-file-info bundle_lid,filepath --sort-by bundle_lid
-            # --output-index-file sort_by_2.csv
+            # Executable command: pds4_create_xml_index ../test_files/labels "tester_label_1.xml" "tester_label_2.xml" "tester_label_3.xml" --limit-xpaths-file ../test_files/samples/elements_clean_header_field_names.txt --add-extra-file-info bundle_lid,filepath --sort-by bundle_lid --output-index-file sort_by_2.csv
             # Compare result to golden copy:
             # test_files/expected/sort_by_success_2.csv
             (
@@ -352,10 +299,7 @@ labels_dir = test_files_dir / 'labels'
                 ]
             ),
 
-            # Executable command: pds4_create_xml_index ../test_files/labels
-            # "identical_label_*.xml" --limit-xpaths-file
-            # ../test_files/samples/identical_elements.txt --add-extra-file-info
-            # filename --sort-by filename --output-index-file identical_labels.csv
+            # Executable command: pds4_create_xml_index ../test_files/labels "identical_label_*.xml" --limit-xpaths-file ../test_files/samples/identical_elements.txt --add-extra-file-info filename --sort-by filename --output-index-file identical_labels.csv
             # Compare result to golden copy:
             # test_files/expected/identical_labels_success.csv
             (
@@ -374,10 +318,7 @@ labels_dir = test_files_dir / 'labels'
                 ]
             ),
 
-            # Executable command: pds4_create_xml_index ../test_files/labels
-            # "nilled_label.xml" --limit-xpaths-file
-            # ../test_files/samples/elements_nilled.txt --output-index-file
-            # nilled_elements.csv
+            # Executable command: pds4_create_xml_index ../test_files/labels "nilled_label.xml" --limit-xpaths-file ../test_files/samples/elements_nilled.txt --output-index-file nilled_elements.csv
             # Compare result to golden copy:
             # test_files/expected/nilled_element_success.csv
             (
@@ -392,8 +333,7 @@ labels_dir = test_files_dir / 'labels'
                 ]
             ),
 
-            # Executable command: pds4_create_xml_index ../test_files/labels
-            # "tester_label_1.xml" --fixed-width --output-index-file fixed_width.csv
+            # Executable command: pds4_create_xml_index ../test_files/labels "tester_label_1.xml" --fixed-width --output-index-file fixed_width.csv
             # Compare result to golden copy:
             # test_files/expected/fixed_width_success.csv
             (
@@ -435,10 +375,7 @@ def test_success(golden_file, new_file, cmd_line):
 @pytest.mark.parametrize(
     'cmd_line',
     [
-        # Executable command: pds4_create_xml_index ../test_files/labels
-        # "tester_label_1.xml" "tester_label_2.xml" "tester_label_3.xml"
-        # --limit-xpaths-file ../test_files/samples/element_1.txt --add-extra-file-info
-        # bad_element --output-headers-file hdout.txt
+        # Executable command: pds4_create_xml_index ../test_files/labels "tester_label_1.xml" "tester_label_2.xml" "tester_label_3.xml" --limit-xpaths-file ../test_files/samples/element_1.txt --add-extra-file-info bad_element --output-headers-file hdout.txt
         (
             str(test_files_dir),
             str(labels_dir.name / Path('tester_label_1.xml')),
@@ -451,10 +388,7 @@ def test_success(golden_file, new_file, cmd_line):
             '--output-headers-file',
         ),
 
-        # Executable command: pds4_create_xml_index ../test_files/labels
-        # "bad_directory/labels/tester_label_*.xml"
-        # --limit-xpaths-file ../test_files/samples/element_1.txt --add-extra-file-info
-        # filename --output-headers-file hdout.txt
+        # Executable command: pds4_create_xml_index ../test_files/labels "bad_directory/labels/tester_label_*.xml" --limit-xpaths-file ../test_files/samples/element_1.txt --add-extra-file-info filename --output-headers-file hdout.txt
         (
             str(test_files_dir),  # directory path
             'bad_directory/labels/tester_label_*.xml',  # non-existent directory
@@ -465,10 +399,7 @@ def test_success(golden_file, new_file, cmd_line):
             '--output-headers-file',
         ),
 
-        # Executable command: pds4_create_xml_index ../test_files/labels
-        # "tester_label_1.xml" "tester_label_2.xml" "tester_label_3.xml"
-        # --limit-xpaths-file ../test_files/samples/element_empty.txt
-        # --output-headers-file hdout.txt
+        # Executable command: pds4_create_xml_index ../test_files/labels "tester_label_1.xml" "tester_label_2.xml" "tester_label_3.xml" --limit-xpaths-file ../test_files/samples/element_empty.txt --output-headers-file hdout.txt
         (
             str(test_files_dir),  # directory path
             str(labels_dir.name / Path('tester_label_1.xml')),
@@ -491,9 +422,7 @@ def test_failures(cmd_line):
 @pytest.mark.parametrize(
     'new_file,cmd_line',
     [
-        # Executable command: pds4_create_xml_index ../test_files/labels
-        # "nilled_label_bad.xml" --limit-xpaths-file
-        # ../test_files/samples/elements_nilled_bad.txt --output-index-file indexout.csv
+        # Executable command: pds4_create_xml_index ../test_files/labels "nilled_label_bad.xml" --limit-xpaths-file ../test_files/samples/elements_nilled_bad.txt --output-index-file indexout.csv
         (
             'nillable.csv',
             [

--- a/tests/test_pds4_create_xml_index_blackbox.py
+++ b/tests/test_pds4_create_xml_index_blackbox.py
@@ -18,6 +18,12 @@ labels_dir = test_files_dir / 'labels'
         'golden_file,new_file,cmd_line',
         [
             # Testing --limit-xpaths-file
+            # Executable command: pds4_create_xml_index ../test_files/labels
+            # "tester_label_1.xml" --limit-xpaths-file
+            # ../test_files/samples/element_1.txt --output-headers-file
+            # limit_xpaths_file.txt
+            # Compare result to golden copy:
+            # test_files/expected/limit_xpaths_file_success_1.txt
             (
                 str(expected_dir / 'limit_xpaths_file_success_1.txt'),
                 'limit_xpaths_file.txt',
@@ -30,6 +36,12 @@ labels_dir = test_files_dir / 'labels'
                 ]
             ),
 
+            # Executable command: pds4_create_xml_index ../test_files/labels
+            # "tester_label_2.xml" --limit-xpaths-file
+            # ../test_files/samples/element_2.txt --output-headers-file
+            # limit_xpaths_file_2.txt
+            # Compare result to golden copy:
+            # test_files/expected/limit_xpaths_file_success_2.txt
             (
                 str(expected_dir / 'limit_xpaths_file_success_2.txt'),
                 'limit_xpaths_file_2.txt',
@@ -42,6 +54,12 @@ labels_dir = test_files_dir / 'labels'
                 ]
             ),
 
+            # Executable command: pds4_create_xml_index ../test_files/labels
+            # "tester_label_2.xml" --limit-xpaths-file
+            # ../test_files/samples/element_duplicates.txt
+            # --output-headers-file elements_dupe_file_2.txt
+            # Compare result to golden copy:
+            # test_files/expected/limit_xpaths_file_success_2.txt
             (
                 str(expected_dir / 'limit_xpaths_file_success_2.txt'),
                 'elements_dupe_file_2.txt',
@@ -54,6 +72,12 @@ labels_dir = test_files_dir / 'labels'
                 ]
             ),
 
+            # Executable command: pds4_create_xml_index ../test_files/labels
+            # "tester_label_2.xml" tester_label_3.xml" --limit-xpaths-file
+            # ../test_files/samples/element_3.txt --output-headers-file
+            # limit_xpaths_file_3.txt
+            # Compare result to golden copy:
+            # test_files/expected/limit_xpaths_file_success_3.txt
             (
                 str(expected_dir / 'limit_xpaths_file_success_3.txt'),
                 'limit_xpaths_file_3.txt',
@@ -67,7 +91,12 @@ labels_dir = test_files_dir / 'labels'
                 ]
             ),
 
-
+            # Executable command: pds4_create_xml_index ../test_files/labels
+            # "tester_label_1.xml" "tester_label_2.xml" "tester_label_3.xml"
+            # --limit-xpaths-file ../test_files/samples/element_4.txt
+            # --output-headers-file limit_xpaths_file_4.txt
+            # Compare result to golden copy:
+            # test_files/expected/limit_xpaths_file_success_4.txt
             (
                 str(expected_dir / 'limit_xpaths_file_success_4.txt'),
                 'limit_xpaths_file_4.txt',
@@ -83,6 +112,11 @@ labels_dir = test_files_dir / 'labels'
             ),
 
             # Testing --simplify-xpaths
+            # Executable command: pds4_create_xml_index ../test_files/labels
+            # "tester_label_1.xml" --simplify-xpaths
+            # --output-headers-file simplify_xpaths_1.txt
+            # Compare result to golden copy:
+            # test_files/expected/simplify_xpaths_success_1.txt
             (
                 str(expected_dir / 'simplify_xpaths_success_1.txt'),
                 'simplify_xpaths_1.txt',
@@ -94,6 +128,14 @@ labels_dir = test_files_dir / 'labels'
                 ]
             ),
 
+            # Testing --simplify-xpaths
+            # Executable command: pds4_create_xml_index ../test_files/labels
+            # "tester_label_1.xml" "tester_label_2.xml" "tester_label_3.xml"
+            # --simplify-xpaths --limit-xpaths-file
+            # ../test_files/samples/elements_xpath_simplify_2.txt
+            # --output-headers-file simplify_xpaths_2.txt
+            # Compare result to golden copy:
+            # test_files/expected/simplify_xpaths_success_2.txt
             (
                 str(expected_dir / 'simplify_xpaths_success_2.txt'),
                 'simplify_xpaths_2.txt',
@@ -109,6 +151,13 @@ labels_dir = test_files_dir / 'labels'
                 ]
             ),
 
+            # Testing --simplify-xpaths
+            # Executable command: pds4_create_xml_index ../test_files/labels
+            # "tester_label_2.xml" --simplify-xpaths --limit-xpaths-file
+            # ../test_files/samples/elements_xpath_simplify_3.txt
+            # --output-headers-file simplify_xpaths_3.txt
+            # Compare result to golden copy:
+            # test_files/expected/simplify_xpaths_success_3.txt
             (
                 str(expected_dir / 'simplify_xpaths_success_3.txt'),
                 'simplify_xpaths_3.txt',
@@ -122,6 +171,13 @@ labels_dir = test_files_dir / 'labels'
                 ]
             ),
 
+            # Testing --simplify-xpaths
+            # Executable command: pds4_create_xml_index ../test_files/labels
+            # "tester_label_3.xml" --simplify-xpaths --limit-xpaths-file
+            # ../test_files/samples/elements_xpath_simplify_4.txt
+            # --output-headers-file simplify_xpaths_4.txt
+            # Compare result to golden copy:
+            # test_files/expected/simplify_xpaths_success_4.txt
             (
                 str(expected_dir / 'simplify_xpaths_success_4.txt'),
                 'simplify_xpaths_4.txt',
@@ -136,6 +192,12 @@ labels_dir = test_files_dir / 'labels'
             ),
 
             # Testing --add-extra-file-info
+            # Executable command: pds4_create_xml_index ../test_files/labels
+            # "tester_label_2.xml" --limit-xpaths-file
+            # ../test_files/samples/element_1.txt --add-extra-file-info filename,filepath
+            # --output-index-file extra_file_info_1.csv
+            # Compare result to golden copy:
+            # test_files/expected/extra_file_info_success_1.csv
             (
                 str(expected_dir / 'extra_file_info_success_1.csv'),
                 'extra_file_info_1.csv',
@@ -150,6 +212,13 @@ labels_dir = test_files_dir / 'labels'
                 ]
             ),
 
+            # Executable command: pds4_create_xml_index ../test_files/labels
+            # "tester_label_1.xml" "tester_label_2.xml" "tester_label_3.xml"
+            # --limit-xpaths-file ../test_files/samples/element_5.txt
+            # --add-extra-file-info filename --sort-by filename
+            # --output-index-file extra_file_info_2.csv
+            # Compare result to golden copy:
+            # test_files/expected/extra_file_info_success_2.csv
             (
                 str(expected_dir / 'extra_file_info_success_2.csv'),
                 'extra_file_info_2.csv',
@@ -168,6 +237,13 @@ labels_dir = test_files_dir / 'labels'
                 ]
             ),
 
+            # Executable command: pds4_create_xml_index ../test_files/labels
+            # "tester_label_1.xml" "tester_label_2.xml" "tester_label_3.xml"
+            # --limit-xpaths-file ../test_files/samples/element_5.txt
+            # --add-extra-file-info filename,filepath,lid,bundle,bundle_lid
+            # --sort-by filename --output-index-file extra_file_info_3.csv
+            # Compare result to golden copy:
+            # test_files/expected/extra_file_info_success_3.csv
             (
                 str(expected_dir / 'extra_file_info_success_3.csv'),
                 'extra_file_info_3.csv',
@@ -187,6 +263,11 @@ labels_dir = test_files_dir / 'labels'
             ),
 
             # Testing --clean-header-field-names
+            # Executable command: pds4_create_xml_index ../test_files/labels
+            # "tester_label_1.xml" --clean-header-field-names
+            # --output-headers-file clean_header_field_names_1.txt
+            # Compare result to golden copy:
+            # test_files/expected/clean_header_field_names_success_1.txt
             (
                 str(expected_dir / 'clean_header_field_names_success_1.txt'),
                 'clean_header_field_names_1.txt',
@@ -198,6 +279,13 @@ labels_dir = test_files_dir / 'labels'
                 ]
             ),
 
+            # Executable command: pds4_create_xml_index ../test_files/labels
+            # "tester_label_1.xml" "tester_label_1.xml" --limit-xpaths-file
+            # ../test_files/samples/elements_clean_header_field_names.txt
+            # --clean-header-field-names
+            # --output-headers-file clean_header_field_names_2.txt
+            # Compare result to golden copy:
+            # test_files/expected/clean_header_field_names_success_2.txt
             (
                 str(expected_dir / 'clean_header_field_names_success_2.txt'),
                 'clean_header_field_names_2.txt',
@@ -213,6 +301,14 @@ labels_dir = test_files_dir / 'labels'
             ),
 
             # Testing --sort by
+            # Executable command: pds4_create_xml_index ../test_files/labels
+            # "tester_label_1.xml" "tester_label_2.xml" "tester_label_3.xml"
+            # --limit-xpaths-file
+            # ../test_files/samples/elements_clean_header_field_names.txt --sort-by
+            # 'pds:Product_Observational/pds:Identification_Area<1>/
+            #  pds:logical_identifier<1>' --output-index-file sort_by_1.csv
+            # Compare result to golden copy:
+            # test_files/expected/sort_by_success_1.csv
             (
                 str(expected_dir / 'sort_by_success_1.csv'),
                 'sort_by_1.csv',
@@ -230,6 +326,14 @@ labels_dir = test_files_dir / 'labels'
                 ]
             ),
 
+            # Executable command: pds4_create_xml_index ../test_files/labels
+            # "tester_label_1.xml" "tester_label_2.xml" "tester_label_3.xml"
+            # --limit-xpaths-file
+            # ../test_files/samples/elements_clean_header_field_names.txt
+            # --add-extra-file-info bundle_lid,filepath --sort-by bundle_lid
+            # --output-index-file sort_by_2.csv
+            # Compare result to golden copy:
+            # test_files/expected/sort_by_success_2.csv
             (
                 str(expected_dir / 'sort_by_success_2.csv'),
                 'sort_by_2.csv',
@@ -248,6 +352,12 @@ labels_dir = test_files_dir / 'labels'
                 ]
             ),
 
+            # Executable command: pds4_create_xml_index ../test_files/labels
+            # "identical_label_*.xml" --limit-xpaths-file
+            # ../test_files/samples/identical_elements.txt --add-extra-file-info
+            # filename --sort-by filename --output-index-file identical_labels.csv
+            # Compare result to golden copy:
+            # test_files/expected/identical_labels_success.csv
             (
                 str(expected_dir / 'identical_labels_success.csv'),
                 'identical_labels.csv',
@@ -263,6 +373,13 @@ labels_dir = test_files_dir / 'labels'
                     '--output-index-file'
                 ]
             ),
+
+            # Executable command: pds4_create_xml_index ../test_files/labels
+            # "nilled_label.xml" --limit-xpaths-file
+            # ../test_files/samples/elements_nilled.txt --output-index-file
+            # nilled_elements.csv
+            # Compare result to golden copy:
+            # test_files/expected/nilled_element_success.csv
             (
                 str(expected_dir / 'nilled_element_success.csv'),
                 'nilled_element.csv',
@@ -274,6 +391,11 @@ labels_dir = test_files_dir / 'labels'
                     '--output-index-file'
                 ]
             ),
+
+            # Executable command: pds4_create_xml_index ../test_files/labels
+            # "tester_label_1.xml" --fixed-width --output-index-file fixed_width.csv
+            # Compare result to golden copy:
+            # test_files/expected/fixed_width_success.csv
             (
                 str(expected_dir / 'fixed_width_success.csv'),
                 'fixed_width.csv',
@@ -313,6 +435,10 @@ def test_success(golden_file, new_file, cmd_line):
 @pytest.mark.parametrize(
     'cmd_line',
     [
+        # Executable command: pds4_create_xml_index ../test_files/labels
+        # "tester_label_1.xml" "tester_label_2.xml" "tester_label_3.xml"
+        # --limit-xpaths-file ../test_files/samples/element_1.txt --add-extra-file-info
+        # bad_element --output-headers-file hdout.txt
         (
             str(test_files_dir),
             str(labels_dir.name / Path('tester_label_1.xml')),
@@ -324,15 +450,25 @@ def test_success(golden_file, new_file, cmd_line):
             'bad_element',
             '--output-headers-file',
         ),
+
+        # Executable command: pds4_create_xml_index ../test_files/labels
+        # "bad_directory/labels/tester_label_*.xml"
+        # --limit-xpaths-file ../test_files/samples/element_1.txt --add-extra-file-info
+        # filename --output-headers-file hdout.txt
         (
             str(test_files_dir),  # directory path
-            ' bad_directory/labels/tester_label_*.xml',  # non-existent directory
+            'bad_directory/labels/tester_label_*.xml',  # non-existent directory
             '--limit-xpaths-file',
             str(samples_dir / 'element_1.txt'),  # elements file
             '--add-extra-file-info',  # extra file info
             'filename',
             '--output-headers-file',
         ),
+
+        # Executable command: pds4_create_xml_index ../test_files/labels
+        # "tester_label_1.xml" "tester_label_2.xml" "tester_label_3.xml"
+        # --limit-xpaths-file ../test_files/samples/element_empty.txt
+        # --output-headers-file hdout.txt
         (
             str(test_files_dir),  # directory path
             str(labels_dir.name / Path('tester_label_1.xml')),
@@ -355,6 +491,9 @@ def test_failures(cmd_line):
 @pytest.mark.parametrize(
     'new_file,cmd_line',
     [
+        # Executable command: pds4_create_xml_index ../test_files/labels
+        # "nilled_label_bad.xml" --limit-xpaths-file
+        # ../test_files/samples/elements_nilled_bad.txt --output-index-file indexout.csv
         (
             'nillable.csv',
             [


### PR DESCRIPTION
The documentation previously stated that an understanding of XPath was necessary to use the tool effectively. This has been replaced with a passage that instead demonstrates how to read and understand the XPath-based headers the tool creates. 

The blackbox unit tests have been given explanatory block comments for each entry. Each block comment contains the equivalent command-line query and the golden copy file to compare the results against.


Fixes #19